### PR TITLE
depend on project not aar

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Before installing the plugin, you must setup your app to receive push notificati
 - [Get FCM Credentials](https://docs.oracle.com/en/cloud/saas/marketing/responsys-develop-mobile/android/gcm-credentials) 
 - Log in to the [Responsys Mobile App Developer Console](https://docs.oracle.com/en/cloud/saas/marketing/responsys-develop-mobile/dev-console/login/) and enter your FCM credentials (Project ID and Server API Key) for your Android app.
 - Get the `pushio_config.json` file generated from your credentials and place it in your project's `android/app/src/main/assets` folder. You might have to create the directory if it is not already present.
-- Download the SDK native binary from [here](https://www.oracle.com/downloads/applications/cx/responsys-mobile-sdk.html) and place it in the project's `android/app/src/main/libs` folder. 
 
 
 ### For iOS
@@ -83,7 +82,7 @@ yarn add @oracle/react-native-pushiomanager
 
 ### For Android
 
-- Place the SDK .aar in your `/android` folder inside of a new directory `/android/PushIOManager`
+- Download the SDK native binary from [here](https://www.oracle.com/downloads/applications/cx/responsys-mobile-sdk.html) and place the SDK .aar in your `/android` folder inside of a new directory `/android/PushIOManager`
 
 - In that new directory create a file `build.gradle` with the following code (where X is the version of the SDK file you placed):
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ yarn add @oracle/react-native-pushiomanager
 
 ### For Android
 
+- Place the SDK .aar in your `/android` folder inside of a new directory `/android/PushIOManager`
+
+- In that new directory create a file `build.gradle` with the following code (where X is the version of the SDK file you placed):
+
+```gradle
+configurations.maybeCreate("default")
+artifacts.add("default", file('PushIOManager-X.XX.X.aar'))
+```
+
+- Add the following to your project wide settings.gradle:
+
+```gradle
+include ':PushIOManager'
+project(':PushIOManager').projectDir = new File(rootProject.projectDir, 'app/PushIOManager')
+```
+
 - Open the `build.gradle` file located in `android/app/` and add the following dependency,
 	```
 	implementation 'com.google.firebase:firebase-messaging:17.3.0' 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ artifacts.add("default", file('PushIOManager-X.XX.X.aar'))
 
 ```gradle
 include ':PushIOManager'
-project(':PushIOManager').projectDir = new File(rootProject.projectDir, 'app/PushIOManager')
+project(':PushIOManager').projectDir = new File(rootProject.projectDir, './PushIOManager')
 ```
 
 - Open the `build.gradle` file located in `android/app/` and add the following dependency,

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,7 +71,7 @@ repositories {
 }
 
 dependencies {
-    implementation rootProject.files('app/src/main/libs/PushIOManager-6.50.aar')
+    implementation project(":PushIOManager")
     //noinspection GradleDynamicVersion
     compileOnly 'com.facebook.react:react-native:+'  // From node_modules
     compileOnly 'com.google.firebase:firebase-messaging:17.3.0'


### PR DESCRIPTION
**Breaking changes**

- Fixes Gradle compilation by depending on the user setting up a project rather than an AAR
- Fixes #29 