### PR TITLE
[chore]: support postinstall to monorepo and custom ios path folder

### DIFF
--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-find_ios_root_path=$(find ./ -type d -name ios ! -path "*/node_modules/*" ! -path "*/.git/*" | head -n 1)
+find_ios_root_path=$(find ../../../ -type d -name ios ! -path "*/node_modules/*" ! -path "*/.git/*" | head -n 1)
 
 default_reactnative_root_path="../../../ios"
 
@@ -16,6 +16,6 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     elif [[ "$find_ios_root_path" ]]; then
         generate_command_by_path $find_ios_root_path
     else
-        generate_command_by_path $default_path
+        generate_command_by_path $default_reactnative_root_path
     fi
 fi

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-rm -rf ./framework/PushIOManager.framework && cp -Rf { echo $PUSH_IO_MANAGER_PATH_IOS }/framework/PushIOManager.framework ./framework/ || { echo "\n\n\n Error ==> PushIOManager.framework not found. Please copy the PushIOManager.framework to YOUR_APP_DIR/ios/framework/ and install package again. Follow README.md Installation instructions.<===  \n\n\n;"
+rm -rf ./framework/PushIOManager.framework && cp -Rf { echo $PUSH_IO_MANAGER_PATH_IOS"/framework/PushIOManager.framework" } ./framework/ || { echo "\n\n\n Error ==> PushIOManager.framework not found. Please copy the PushIOManager.framework to YOUR_APP_DIR/ios/framework/ and install package again. Follow README.md Installation instructions.<===  \n\n\n;" $PUSH_IO_MANAGER_PATH_IOS"/framework/PushIOManager.framework"
  exit 1; }
  fi

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,6 +1,21 @@
 #!/bin/sh
 
+find_ios_root_path=$(find ./ -type d -name ios ! -path "*/node_modules/*" ! -path "*/.git/*" | head -n 1)
+
+default_reactnative_root_path="../../../ios"
+
+generate_command_by_path() {
+    rm -rf ./framework/PushIOManager.framework && cp -Rf $( echo $1 )/framework/PushIOManager.framework ./framework/ || { echo "\n\n\n Error ==> PushIOManager.framework not found. Please copy the PushIOManager.framework to YOUR_APP_DIR/ios/framework/ and install package again. Follow README.md Installation instructions.<===  \n\n\n;"
+    exit 1; }
+}
+
+# NOTE: to declare variable by bash need to use export CUSTOM_IOS_PATH_PUSHIOMANAGER = path/to/ios/folder
 if [[ "$OSTYPE" == "darwin"* ]]; then
-rm -rf ./framework/PushIOManager.framework && cp -Rf { echo $PUSH_IO_MANAGER_PATH_IOS"/framework/PushIOManager.framework" } ./framework/ || { echo "\n\n\n Error ==> PushIOManager.framework not found. Please copy the PushIOManager.framework to YOUR_APP_DIR/ios/framework/ and install package again. Follow README.md Installation instructions.<===  \n\n\n;" $PUSH_IO_MANAGER_PATH_IOS"/framework/PushIOManager.framework"
- exit 1; }
- fi
+    if [[ ! -z "${CUSTOM_IOS_PATH_PUSHIOMANAGER}" ]]; then
+        generate_command_by_path $CUSTOM_IOS_PATH_PUSHIOMANAGER
+    elif [[ "$find_ios_root_path" ]]; then
+        generate_command_by_path $find_ios_root_path
+    else
+        generate_command_by_path $default_path
+    fi
+fi

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-rm -rf ./framework/PushIOManager.framework && cp -Rf ../../../ios/framework/PushIOManager.framework ./framework/ || { echo "\n\n\n Error ==> PushIOManager.framework not found. Please copy the PushIOManager.framework to YOUR_APP_DIR/ios/framework/ and install package again. Follow README.md Installation instructions.<===  \n\n\n;"
+rm -rf ./framework/PushIOManager.framework && cp -Rf { echo $PUSH_IO_MANAGER_PATH_IOS }/framework/PushIOManager.framework ./framework/ || { echo "\n\n\n Error ==> PushIOManager.framework not found. Please copy the PushIOManager.framework to YOUR_APP_DIR/ios/framework/ and install package again. Follow README.md Installation instructions.<===  \n\n\n;"
  exit 1; }
  fi


### PR DESCRIPTION
**Context**
To be able support to monorepo and custom path in postinstall

**Description**
Enable the postinstall.sh script to accept a user given path to your ios folder or the script itself will fetch the iOS folder. If none of the options work, it will work as in the current version.

**Steps**

1. In your bash declare

```sh
export CUSTOM_IOS_PATH_PUSHIOMANAGER
```

2. The script going to use the command `find` to search `ios` folder in the project

3. if none of the other steps work, it will run as it currently does.

**Breaking changes**
N/A